### PR TITLE
校正了parallelism_tutorial

### DIFF
--- a/tutorial/zh/beginner_source/former_torchies/parallelism_tutorial.py
+++ b/tutorial/zh/beginner_source/former_torchies/parallelism_tutorial.py
@@ -3,12 +3,12 @@
 Multi-GPU examples
 ==================
 
-数据并行性是指当我们将 mini-batch 的样本分成更小的
-mini-batches, 并行的计算每个更小的 mini-batches.
+数据并行是指当我们将 mini-batch 的样本分成更小的
+mini-batches, 并行地计算每个更小的 mini-batches.
 
-数据并行性使用 ``torch.nn.DataParallel`` 实现.
-可以在 ``DataParallel`` 中封装一个模块,  在 batch 维度
-它将通过多个 GPUs 并行化.
+数据并行通过使用 ``torch.nn.DataParallel`` 实现.
+我们可以用 ``DataParallel`` 包装一个模块,  然后它将在 batch 维度(默认是0轴)
+平分数据给多个 GPUs 进行并行计算.
 
 DataParallel
 -------------
@@ -22,7 +22,7 @@ class DataParallelModel(nn.Module):
         super().__init__()
         self.block1 = nn.Linear(10, 20)
 
-        # 在 DataParallel 中打包 block2
+        # 用 DataParallel 包装 block2
         self.block2 = nn.Linear(20, 20)
         self.block2 = nn.DataParallel(self.block2)
 
@@ -35,7 +35,7 @@ class DataParallelModel(nn.Module):
         return x
 
 ########################################################################
-# 这个代码不需要在 CPU 模式下更改.
+# 这个代码不做任何修改，在 CPU 模式下也能运行.
 #
 # DataParallel 的文档为
 # `here <http://pytorch.org/docs/nn.html#torch.nn.DataParallel>`_.
@@ -70,7 +70,7 @@ def data_parallel(module, input, device_ids, output_device=None):
 # Part of the model on CPU and part on the GPU
 # --------------------------------------------
 #
-# 让我们来看一个实现网络的一部分在 CPU 另一部分在 GPU 的例子
+# 让我们来看一个网络模型，他的网络一部分用 CPU 运算，另一部分用 GPU 运算。
 
 
 class DistributedModel(nn.Module):
@@ -95,7 +95,7 @@ class DistributedModel(nn.Module):
 ########################################################################
 #
 # 这是对前 Torch 使用者关于 PyTorch 的一个小的介绍.
-# 还有更多东西可以学习.
+# 当然还有更多东西需要学习.
 #
 # 看看我们更全面的入门教程, 它介绍了 ``optim`` package,
 # data loaders 等.: :doc:`/beginner/deep_learning_60min_blitz`.


### PR DESCRIPTION
patallelism_totorial.py后面那块是不翻译吗？
这一块。
```
# -  :doc:`Train neural nets to play video games </intermediate/reinforcement_q_learning>`
# -  `Train a state-of-the-art ResNet network on imagenet`_
# -  `Train an face generator using Generative Adversarial Networks`_
# -  `Train a word-level language model using Recurrent LSTM networks`_
# -  `More examples`_
# -  `More tutorials`_
# -  `Discuss PyTorch on the Forums`_
# -  `Chat with other users on Slack`_
#
# .. _`Deep Learning with PyTorch: a 60-minute blitz`: https://github.com/pytorch/tutorials/blob/master/Deep%20Learning%20with%20PyTorch.ipynb
# .. _Train a state-of-the-art ResNet network on imagenet: https://github.com/pytorch/examples/tree/master/imagenet
# .. _Train an face generator using Generative Adversarial Networks: https://github.com/pytorch/examples/tree/master/dcgan
# .. _Train a word-level language model using Recurrent LSTM networks: https://github.com/pytorch/examples/tree/master/word_language_model
# .. _More examples: https://github.com/pytorch/examples
# .. _More tutorials: https://github.com/pytorch/tutorials
# .. _Discuss PyTorch on the Forums: https://discuss.pytorch.org/
# .. _Chat with other users on Slack: http://pytorch.slack.com/messages/beginner/

```
如果不翻译的话 。 为以前 Torch 用户提供的 Pytorch 教程  这一章 全部校正完毕
