### PR TITLE
fix:#533 更正 1.0 版本的雅可比矩阵定义错误。

### DIFF
--- a/docs/1.0/blitz_autograd_tutorial.md
+++ b/docs/1.0/blitz_autograd_tutorial.md
@@ -136,9 +136,9 @@ tensor([[4.5000, 4.5000],
 
 $$
 J=\left(\begin{array}{ccc}
-   \frac{\partial y_{1}}{\partial x_{1}} & \cdots & \frac{\partial y_{m}}{\partial x_{1}}\\
+   \frac{\partial y_{1}}{\partial x_{1}} & \cdots & \frac{\partial y_{1}}{\partial x_{n}}\\
    \vdots & \ddots & \vdots\\
-   \frac{\partial y_{1}}{\partial x_{n}} & \cdots & \frac{\partial y_{m}}{\partial x_{n}}
+   \frac{\partial y_{m}}{\partial x_{1}} & \cdots & \frac{\partial y_{m}}{\partial x_{n}}
    \end{array}\right)
 $$
 


### PR DESCRIPTION
我检查了一下，除了1.4版本，目前只在 1.0 版本存在这个定义。