### PR TITLE
Update 04.md

### DIFF
--- a/docs/1.7/04.md
+++ b/docs/1.7/04.md
@@ -144,7 +144,7 @@ tensor([True, True])
 *   运行请求的操作以计算结果张量，并且
 *   在 DAG 中维护操作的*梯度函数*。
 
-当在 DAG 根目录上调用`.backward()`时，后退通道开始。 `autograd`然后：
+当在 DAG 根目录上调用`.backward()`时，反向传递开始。 `autograd`然后：
 
 *   从每个`.grad_fn`计算梯度，
 *   将它们累积在各自的张量的`.grad`属性中，然后


### PR DESCRIPTION
The backward pass kicks off when .backward() is called on the DAG root